### PR TITLE
Fix point multiplier after merging two planes

### DIFF
--- a/components/AircraftPanel.tsx
+++ b/components/AircraftPanel.tsx
@@ -30,7 +30,7 @@ export const AircraftPanel:NextPage = () => {
           aircraft._id="blank " + new Date().getTime()
         } else if (aircraft._id==aircraftEndID) {
           aircraft.level+=1
-          aircraft.money_per_second*=1.2
+          aircraft.money_per_second*=2.1
         }
       })
       


### PR DESCRIPTION
Merging two planes should get little more money than the non-merged planes (2.1 is a little more than 2) because originally it was 1.2 which is less than 2 so it loses most points per second when it originally merged.